### PR TITLE
Added UWP support

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -34,7 +34,7 @@ function isReactNative(path) {
   }
   try {
     const pkg = JSON.parse(fs.readFileSync(`${path}/package.json`));
-    if (pkg.name !== 'react-native') {
+    if (pkg.name !== 'react-native' && pkg.name != 'react-native-windows') {
       console.error(`Not react-native:\n${path}\n`);
       return false;
     }

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function(path, oldPort, newPort) {
 
   console.log(`Replacing react-native hard coded port ${oldPort} with ${newPort}...`);
   walkSync(path,
-    /\.(m|h|js|java|pbxproj)$/,
+    /\.(m|h|js|java|pbxproj|cs)$/,
     (file) => {
       const content = fs.readFileSync(file, 'utf8');
       if (portPattern.test(content)) {


### PR DESCRIPTION
This change adds Universal Windows support. There are probably cleaner ways of doing it but you can now run this as a one-liner.
For example:
```
scripts: {
    "postinstall": "react-native-port-patcher --new-port 8082&&react-native-port-patcher --path node_modules/react-native-windows --new-port 8082"
}
```