### PR TITLE
Update package to support Lean Core and @react-native-community

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ Then update your `package.json` to include:
   }
 ```
 
-Now after you [yarn][] or `npm install`, the script will find your `react-native` package under `node_modules` and regex search/replace all instances of `/\b8081\b/g` with the port you provide.
+Now after you [yarn][] or `npm install`, the script will find your `react-native` package and @react-native-community projects under `node_modules` and regex search/replace all instances of `/\b8081\b/g` with the port you provide.
 
 [yarn]:https://yarnpkg.com/en/

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,7 +6,7 @@ const sysPath = require('path');
 const replacePort = require('..');
 
 const options = commandLineArgs([
-  { name: 'path', multiple: true, defaultValue: [
+  { name: 'path', type: String, multiple: true, defaultValue: [
     `${__dirname}/../../react-native`,
     `${__dirname}/../../@react-native-community`
   ]},

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,7 +6,10 @@ const sysPath = require('path');
 const replacePort = require('..');
 
 const options = commandLineArgs([
-  { name: 'path', type: String, defaultValue: `${__dirname}/../../react-native`},
+  { name: 'path', multiple: true, defaultValue: [
+    `${__dirname}/../../react-native`,
+    `${__dirname}/../../@react-native-community`
+  ]},
   { name: 'new-port', type: Number, defaultValue: 8088 },
   { name: 'old-port', type: Number, defaultValue: 8081 },
 ]);
@@ -14,9 +17,9 @@ const options = commandLineArgs([
 const usage = `Usage: react-native-port-patcher [OPTIONS]
 
 Options:
---path      Path to the react-native package installed under your project's
-            node_modules folder. In most cases this can be automatically
-            determined (default: automatic)
+--path      Paths to the react-native package and @react-native-community packages installed
+            under your project's node_modules folder. In most cases this can be automatically
+            determined, if specifying manually, provide multiple paths (default: automatic)
 --new-port  Port to use for react native server (default: 8088)
 --old-port  Port to replace. This is the port which is hard-coded into
             react-native. Keep the default value, unless you've already changed
@@ -28,27 +31,38 @@ function isReactNative(path) {
     console.error(`Path does not exist:\n${path}\n`);
     return false;
   }
+  if (sysPath.basename(path) === '@react-native-community') {
+    // Allow passing the whole @react-native-community folder in node_modules.
+    return true;
+  }
   if (!fs.existsSync(`${path}/package.json`)) {
     console.error(`Not an npm package:\n${path}\n`);
     return false;
   }
   try {
     const pkg = JSON.parse(fs.readFileSync(`${path}/package.json`));
-    if (pkg.name !== 'react-native' && pkg.name != 'react-native-windows') {
-      console.error(`Not react-native:\n${path}\n`);
+    if (pkg.name !== 'react-native' &&
+        pkg.name !== 'react-native-windows' &&
+        !pkg.name.startsWith('@react-native-community/')
+    ) {
+      console.error(`Not react-native or @react-native-community:\n${path}\n`);
       return false;
     }
   } catch (e) {
-    console.error(`Error in react-native package.json:\n${e}\n`);
+    console.error(`Error in ${path} package.json:\n${e}\n`);
     return false;
   }
   return true;
 }
 
-options.path = sysPath.resolve(options.path);
-if (!isReactNative(options.path)) {
-  console.error(usage);
-  process.exit(1);
+function processPath(path) {
+  const resolvedPath = sysPath.resolve(path);
+  if (!isReactNative(resolvedPath)) {
+    console.error(usage);
+    process.exit(1);
+  }
+
+  replacePort(resolvedPath, options['old-port'], options['new-port']);
 }
 
-replacePort(options.path, options['old-port'], options['new-port']);
+options.path.forEach(processPath);

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 
 function walkSync(dir, pattern, cb) {
   fs.readdirSync(dir).forEach(function(file) {
@@ -11,12 +12,12 @@ function walkSync(dir, pattern, cb) {
   });
 }
 
-module.exports = function(path, oldPort, newPort) {
+module.exports = function(packagePath, oldPort, newPort) {
   const portPattern = new RegExp(`\\b${oldPort}\\b`, 'g');
 
-  console.log(`Replacing react-native hard coded port ${oldPort} with ${newPort}...`);
-  walkSync(path,
-    /\.(m|h|js|java|pbxproj|cs)$/,
+  console.log(`Replacing ${path.basename(packagePath)} hard coded port ${oldPort} with ${newPort}...`);
+  walkSync(packagePath,
+    /\.(m|h|js|java|pbxproj|cs|ts)$/,
     (file) => {
       const content = fs.readFileSync(file, 'utf8');
       if (portPattern.test(content)) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-port-patcher",
-  "version": "1.0.3",
-  "description": "Replace all instances of hard coded port 8081 in react-native package",
+  "version": "1.0.4",
+  "description": "Replace all instances of hard coded port 8081 in react-native and @react-native-community packages",
   "main": "index.js",
   "bin": {
     "react-native-port-patcher": "./bin/cli.js"


### PR DESCRIPTION
On my react-native `0.60.4` install this is the output after this update. Prior to this, my app build was still talking to the right server but the detection of a running server would fail and start a server on 8081 even though the app was talking to 8082 and I had a server running on 8082 (from an `npx react-native start --port 8082` command).

This change updates the logic to look at multiple locations and make it willing to run on the `@react-native-community` folder that hosts packages from: https://github.com/react-native-community/cli

```
Replacing react-native hard coded port 8081 with 8082...
  - <package>/node_modules/react-native/Libraries/Core/Devtools/getDevServer.js
  - <package>/node_modules/react-native/Libraries/Utilities/HMRClient.js
  - <package>/node_modules/react-native/React/Base/RCTBridgeDelegate.h
  - <package>/node_modules/react-native/React/Base/RCTDefines.h
  - <package>/node_modules/react-native/React/DevSupport/RCTDevMenu.m
  - <package>/node_modules/react-native/React/React.xcodeproj/project.pbxproj
  - <package>/node_modules/react-native/node_modules/@react-native-community/cli/build/commands/server/middleware/statusPageMiddleware.js
  - <package>/node_modules/react-native/node_modules/@react-native-community/cli/build/tools/loadMetroConfig.js
  - <package>/node_modules/react-native/template/ios/HelloWorld.xcodeproj/project.pbxproj
Replacing @react-native-community hard coded port 8081 with 8082...
  - <package>/node_modules/@react-native-community/cli-platform-android/build/commands/runAndroid/index.js
  - <package>/node_modules/@react-native-community/cli-platform-android/build/commands/runAndroid/tryRunAdbReverse.js
  - <package>/node_modules/@react-native-community/cli-platform-ios/build/commands/runIOS/index.js
  - <package>/node_modules/@react-native-community/cli-tools/build/isPackagerRunning.js
```